### PR TITLE
To use zstd command

### DIFF
--- a/impl/build_archive.sh
+++ b/impl/build_archive.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 FILE_LIST=$1
 ARCHIVE=$2
 
-tar --create --file=- -v --verbatim-files-from "--files-from=$FILE_LIST" --zstd | gpg -c --cipher-algo AES256 --passphrase-file config/passphrase.txt --batch >"$ARCHIVE"
+tar --create -v --verbatim-files-from "--files-from=$FILE_LIST" | zstd | gpg -c --cipher-algo AES256 --passphrase-file config/passphrase.txt --batch >"$ARCHIVE"


### PR DESCRIPTION
To rely on zstd command rather than a tar version that support zstd